### PR TITLE
Increase max function runtime to 60 seconds

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "version": 2,
+  "functions": {
+    "app/api/**/*": {
+      "maxDuration": 60
+    }
+  }
+}


### PR DESCRIPTION
:warning: This _should_ work for Python API routes, but I'm not sure. **You should probably allow a preview deployment and test it to make sure it works okay.**

Configuration:

```json
{
  "version": 2,
  "functions": {
    "app/api/**/*": {
      "maxDuration": 60
    }
  }
}
```

Saved in `vercel.json`, should increase API timeout to 60 seconds. There might be other timeout issues too, but this will fix any related to Vercel serverless functions.